### PR TITLE
improve perf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "twitter-api-client": "^1.4.0"
       },
       "devDependencies": {
-        "astro": "^0.23.7",
+        "astro": "^0.24.0",
         "autoprefixer": "^10.3.7",
         "prettier-plugin-astro": "^0.0.12",
         "tailwindcss": "^3.0.15"
@@ -34,23 +34,25 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.11.4.tgz",
-      "integrity": "sha512-T598FTCgBFjjPLPClvn+lc2SFGAJkjaF+lbxvHNjzmUpOYdz7YyH1apd3XAZvDp5r5WBBhicB6693GhQRpf3oQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.12.0.tgz",
+      "integrity": "sha512-P1OibxzBRkWz18FL9IClI4WIOL6fFHqrmYq+/Ygw3ya0GHeDZ8pLFVpLXTPKMdHoys43dwffPA/6pWaFygBlEw==",
       "dev": true,
       "dependencies": {
-        "typescript": "^4.3.5"
+        "tsm": "^2.2.1",
+        "uvu": "^0.5.3"
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "0.8.6",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-0.8.10.tgz",
+      "integrity": "sha512-F3ceZrBKywnNkDq9mK/6RgRDAGUAv9Z45oljpBx9dlMQHnWOnPdJFWncw1jVItAT57SEflLJqTuFaDphKQAFtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "source-map": "^0.7.3",
         "ts-morph": "^12.0.0",
-        "typescript": "^4.5.2",
+        "typescript": "^4.5.4",
         "vscode-css-languageservice": "^5.1.1",
         "vscode-emmet-helper": "2.1.2",
         "vscode-html-languageservice": "^3.0.3",
@@ -178,10 +180,11 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/@astropub/webapi": {
-      "version": "0.10.14",
-      "dev": true,
-      "license": "(CC0-1.0 AND MIT)"
+    "node_modules/@astrojs/webapi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/webapi/-/webapi-0.11.0.tgz",
+      "integrity": "sha512-hzltX2kPjAX0zEKymU7ceDLCqkZN0ztgucqAzyvM62TJdznv/HRniJz850qKcqAcoTqDXBH5j/5FCO0GXSQLbw==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -529,25 +532,28 @@
       }
     },
     "node_modules/@emmetio/abbreviation": {
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz",
+      "integrity": "sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.0"
       }
     },
     "node_modules/@emmetio/css-abbreviation": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz",
+      "integrity": "sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.0"
       }
     },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==",
+      "dev": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.5",
@@ -604,6 +610,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
     },
     "node_modules/@proload/core": {
       "version": "0.2.2",
@@ -692,8 +704,9 @@
     },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.7",
         "minimatch": "^3.0.4",
@@ -703,8 +716,9 @@
     },
     "node_modules/@ts-morph/common/node_modules/mkdirp": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -719,43 +733,6 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.1.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.6.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.14.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.3.0"
       }
     },
     "node_modules/@types/debug": {
@@ -885,12 +862,6 @@
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "license": "MIT"
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.2.tgz",
-      "integrity": "sha512-sUWMriymrSqTvxCmCkf+7k392TNDcMJBHI1/rysWJxKnWAan/Zk4gZ/GEieSRo4EqIEPpbGU3Sd/0KTRoIA3pA==",
-      "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "2.2.2",
@@ -1089,8 +1060,9 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1171,64 +1143,62 @@
       }
     },
     "node_modules/astro": {
-      "version": "0.23.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.23.7.tgz",
-      "integrity": "sha512-2hoh9NDhDpy25AKsdD/KRNzl832F46/t2dvyaKo5LfnTvJEBV0agPTOC4K6wI3IDqDQBTiizHXwqgm3e/lX7rA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.24.0.tgz",
+      "integrity": "sha512-KN0EtbypW+OC2MQOEH2wBcNlX0Vuu/+DMLVCJsaH2RnvzONunuWxZdNxKCO8EM7fnx8TlH+vA9VaBXcdm5iWTA==",
       "dev": true,
       "dependencies": {
-        "@astrojs/compiler": "^0.11.4",
-        "@astrojs/language-server": "^0.8.6",
+        "@astrojs/compiler": "^0.12.0",
+        "@astrojs/language-server": "^0.8.10",
         "@astrojs/markdown-remark": "^0.6.4",
         "@astrojs/prism": "0.4.0",
         "@astrojs/renderer-preact": "^0.5.0",
         "@astrojs/renderer-react": "0.5.0",
         "@astrojs/renderer-svelte": "0.5.1",
         "@astrojs/renderer-vue": "0.4.0",
-        "@astropub/webapi": "^0.10.1",
-        "@babel/core": "^7.15.8",
-        "@babel/traverse": "^7.15.4",
+        "@astrojs/webapi": "^0.11.0",
+        "@babel/core": "^7.17.5",
+        "@babel/traverse": "^7.17.3",
         "@proload/core": "^0.2.2",
-        "@proload/plugin-tsm": "^0.1.0",
-        "@types/babel__core": "^7.1.15",
-        "@types/debug": "^4.1.7",
-        "@types/yargs-parser": "^20.2.1",
+        "@proload/plugin-tsm": "^0.1.1",
         "@web/parse5-utils": "^1.3.0",
-        "ci-info": "^3.2.0",
+        "ci-info": "^3.3.0",
         "common-ancestor-path": "^1.0.1",
+        "debug": "^4.3.3",
         "eol": "^0.9.1",
-        "es-module-lexer": "^0.9.3",
-        "esbuild": "0.13.7",
-        "estree-walker": "^3.0.0",
-        "fast-glob": "^3.2.7",
-        "fast-xml-parser": "^4.0.0-beta.3",
+        "es-module-lexer": "^0.10.0",
+        "esbuild": "0.14.25",
+        "estree-walker": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "fast-xml-parser": "^4.0.6",
         "html-entities": "^2.3.2",
-        "htmlparser2": "^7.1.2",
+        "htmlparser2": "^7.2.0",
         "kleur": "^4.1.4",
-        "magic-string": "^0.25.7",
-        "micromorph": "^0.1.1",
+        "magic-string": "^0.25.9",
+        "micromorph": "^0.1.2",
         "mime": "^3.0.0",
         "parse5": "^6.0.1",
         "path-to-regexp": "^6.2.0",
-        "postcss": "^8.3.8",
-        "prismjs": "^1.25.0",
-        "rehype-slug": "^5.0.0",
-        "resolve": "^1.20.0",
-        "rollup": "^2.64.0",
+        "postcss": "^8.4.8",
+        "prismjs": "^1.27.0",
+        "rehype-slug": "^5.0.1",
+        "resolve": "^1.22.0",
+        "rollup": "^2.70.0",
         "semver": "^7.3.5",
-        "send": "^0.17.1",
         "serialize-javascript": "^6.0.0",
-        "shiki": "^0.10.0",
+        "shiki": "^0.10.1",
         "shorthash": "^0.0.2",
+        "sirv": "^2.0.2",
         "slash": "^4.0.0",
         "sourcemap-codec": "^1.4.8",
         "srcset-parse": "^1.1.0",
-        "string-width": "^5.0.0",
+        "string-width": "^5.1.2",
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
         "vite": "^2.8.6",
-        "yargs-parser": "^21.0.0",
-        "zod": "^3.8.1"
+        "yargs-parser": "^21.0.1",
+        "zod": "^3.13.4"
       },
       "bin": {
         "astro": "astro.js"
@@ -1547,8 +1517,9 @@
     },
     "node_modules/code-block-writer": {
       "version": "10.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -1758,15 +1729,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
@@ -1775,12 +1737,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -1895,13 +1851,8 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
     "node_modules/electron-to-chromium": {
@@ -1909,27 +1860,20 @@
       "license": "ISC"
     },
     "node_modules/emmet": {
-      "version": "2.3.5",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.3.6.tgz",
+      "integrity": "sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@emmetio/abbreviation": "^2.2.2",
+        "@emmetio/abbreviation": "^2.2.3",
         "@emmetio/css-abbreviation": "^2.1.4"
       }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/entities": {
       "version": "3.0.1",
@@ -1989,9 +1933,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.9.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.0.tgz",
+      "integrity": "sha512-0fHYovx7ETE13wPL8zG/V+ElEgSeSwsgRVOvNZ+g/Y/2YyJq75+IEY4ZBr59vUZ3Voci1jBIktwpj8oODaWa+g==",
+      "dev": true
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -2023,44 +1968,359 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.13.7",
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+      "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
+      "engines": {
+        "node": ">=12"
+      },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.13.7",
-        "esbuild-darwin-64": "0.13.7",
-        "esbuild-darwin-arm64": "0.13.7",
-        "esbuild-freebsd-64": "0.13.7",
-        "esbuild-freebsd-arm64": "0.13.7",
-        "esbuild-linux-32": "0.13.7",
-        "esbuild-linux-64": "0.13.7",
-        "esbuild-linux-arm": "0.13.7",
-        "esbuild-linux-arm64": "0.13.7",
-        "esbuild-linux-mips64le": "0.13.7",
-        "esbuild-linux-ppc64le": "0.13.7",
-        "esbuild-netbsd-64": "0.13.7",
-        "esbuild-openbsd-64": "0.13.7",
-        "esbuild-sunos-64": "0.13.7",
-        "esbuild-windows-32": "0.13.7",
-        "esbuild-windows-64": "0.13.7",
-        "esbuild-windows-arm64": "0.13.7"
+        "esbuild-android-64": "0.14.25",
+        "esbuild-android-arm64": "0.14.25",
+        "esbuild-darwin-64": "0.14.25",
+        "esbuild-darwin-arm64": "0.14.25",
+        "esbuild-freebsd-64": "0.14.25",
+        "esbuild-freebsd-arm64": "0.14.25",
+        "esbuild-linux-32": "0.14.25",
+        "esbuild-linux-64": "0.14.25",
+        "esbuild-linux-arm": "0.14.25",
+        "esbuild-linux-arm64": "0.14.25",
+        "esbuild-linux-mips64le": "0.14.25",
+        "esbuild-linux-ppc64le": "0.14.25",
+        "esbuild-linux-riscv64": "0.14.25",
+        "esbuild-linux-s390x": "0.14.25",
+        "esbuild-netbsd-64": "0.14.25",
+        "esbuild-openbsd-64": "0.14.25",
+        "esbuild-sunos-64": "0.14.25",
+        "esbuild-windows-32": "0.14.25",
+        "esbuild-windows-64": "0.14.25",
+        "esbuild-windows-arm64": "0.14.25"
       }
     },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.13.7",
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+      "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+      "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+      "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+      "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+      "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+      "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+      "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+      "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+      "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+      "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+      "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+      "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+      "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+      "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+      "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+      "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+      "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+      "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+      "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+      "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2068,12 +2328,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -2124,15 +2378,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT"
@@ -2164,9 +2409,10 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.1",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.6.tgz",
+      "integrity": "sha512-RHz47iX/DKT6BQwYQUmKG/1fuC5g2s/TibpxNvE+0ysnpSJxePFzsJvRDtfGhLRg3zdKMzO6EJn8n7+AJ6pSHg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -2222,15 +2468,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/infusion"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2670,22 +2907,6 @@
         "domhandler": "^4.2.2",
         "domutils": "^2.8.0",
         "entities": "^3.0.1"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/ieee754": {
@@ -3231,8 +3452,9 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -3283,11 +3505,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/map-obj": {
@@ -4385,6 +4608,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
@@ -4525,18 +4757,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -4657,8 +4877,9 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -4707,10 +4928,11 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.6",
-      "license": "MIT",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "dependencies": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -4897,15 +5119,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/react": {
@@ -5258,9 +5471,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.68.0",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5371,63 +5585,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
-      "dev": true,
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.8.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "dev": true,
@@ -5435,12 +5592,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
     },
     "node_modules/shiki": {
       "version": "0.10.1",
@@ -5475,6 +5626,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
+      "integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "4.0.0",
       "dev": true,
@@ -5503,8 +5668,9 @@
     },
     "node_modules/source-map": {
       "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
@@ -5570,19 +5736,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/string-width": {
-      "version": "5.1.0",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -5637,8 +5795,9 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -5679,8 +5838,9 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/style-to-object": {
       "version": "0.3.0",
@@ -5945,13 +6105,13 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+    "node_modules/totalist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.0.tgz",
+      "integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
       "dev": true,
       "engines": {
-        "node": ">=0.6"
+        "node": ">=6"
       }
     },
     "node_modules/trim-newlines": {
@@ -5972,8 +6132,9 @@
     },
     "node_modules/ts-morph": {
       "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.2.0.tgz",
+      "integrity": "sha512-WHXLtFDcIRwoqaiu0elAoZ/AmI+SwwDafnPKjgJmdwJ2gRVO0jMKBt88rV2liT/c6MTsXyuWbGFiHe9MRddWJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ts-morph/common": "~0.11.1",
         "code-block-writer": "^10.1.1"
@@ -6008,47 +6169,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/tsm/node_modules/esbuild": {
-      "version": "0.14.11",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.11",
-        "esbuild-darwin-64": "0.14.11",
-        "esbuild-darwin-arm64": "0.14.11",
-        "esbuild-freebsd-64": "0.14.11",
-        "esbuild-freebsd-arm64": "0.14.11",
-        "esbuild-linux-32": "0.14.11",
-        "esbuild-linux-64": "0.14.11",
-        "esbuild-linux-arm": "0.14.11",
-        "esbuild-linux-arm64": "0.14.11",
-        "esbuild-linux-mips64le": "0.14.11",
-        "esbuild-linux-ppc64le": "0.14.11",
-        "esbuild-linux-s390x": "0.14.11",
-        "esbuild-netbsd-64": "0.14.11",
-        "esbuild-openbsd-64": "0.14.11",
-        "esbuild-sunos-64": "0.14.11",
-        "esbuild-windows-32": "0.14.11",
-        "esbuild-windows-64": "0.14.11",
-        "esbuild-windows-arm64": "0.14.11"
-      }
-    },
-    "node_modules/tsm/node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.11",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
     },
     "node_modules/twitter-api-client": {
       "version": "1.5.1",
@@ -6399,58 +6519,11 @@
         }
       }
     },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.14.23",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.23",
-        "esbuild-darwin-64": "0.14.23",
-        "esbuild-darwin-arm64": "0.14.23",
-        "esbuild-freebsd-64": "0.14.23",
-        "esbuild-freebsd-arm64": "0.14.23",
-        "esbuild-linux-32": "0.14.23",
-        "esbuild-linux-64": "0.14.23",
-        "esbuild-linux-arm": "0.14.23",
-        "esbuild-linux-arm64": "0.14.23",
-        "esbuild-linux-mips64le": "0.14.23",
-        "esbuild-linux-ppc64le": "0.14.23",
-        "esbuild-linux-riscv64": "0.14.23",
-        "esbuild-linux-s390x": "0.14.23",
-        "esbuild-netbsd-64": "0.14.23",
-        "esbuild-openbsd-64": "0.14.23",
-        "esbuild-sunos-64": "0.14.23",
-        "esbuild-windows-32": "0.14.23",
-        "esbuild-windows-64": "0.14.23",
-        "esbuild-windows-arm64": "0.14.23"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.23",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vscode-css-languageservice": {
-      "version": "5.1.9",
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.13.tgz",
+      "integrity": "sha512-FA0foqMzMmEoO0WJP+MjoD4dRERhKS+Ag+yBrtmWQDmw2OuZ1R/5FkvI/XdTkCpHmTD9VMczugpHRejQyTXCNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.16.0",
@@ -6460,8 +6533,10 @@
     },
     "node_modules/vscode-emmet-helper": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.1.2.tgz",
+      "integrity": "sha512-Fy6UNawSgxE3Kuqi54vSXohf03iOIrp1A74ReAgzvGP9Yt7fUAvkqF6No2WAc34/w0oWAHAeqoBNqmKKWh6U5w==",
+      "deprecated": "This package has been renamed to @vscode/emmet-helper, please update to the new name",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emmet": "^2.1.5",
         "jsonc-parser": "^2.3.0",
@@ -6473,18 +6548,21 @@
     },
     "node_modules/vscode-emmet-helper/node_modules/jsonc-parser": {
       "version": "2.3.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true
     },
     "node_modules/vscode-emmet-helper/node_modules/vscode-uri": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+      "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
+      "dev": true
     },
     "node_modules/vscode-html-languageservice": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.2.0.tgz",
+      "integrity": "sha512-aLWIoWkvb5HYTVE0kI9/u3P0ZAJGrYOSAAE6L0wqB9radKRtbJNrF9+BjSUFyCgBdNBE/GFExo35LoknQDJrfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "3.16.0-next.2",
@@ -6494,26 +6572,30 @@
     },
     "node_modules/vscode-html-languageservice/node_modules/vscode-languageserver-types": {
       "version": "3.16.0-next.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+      "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
+      "dev": true
     },
     "node_modules/vscode-html-languageservice/node_modules/vscode-uri": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+      "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
+      "dev": true
     },
     "node_modules/vscode-jsonrpc": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "^3.15.3"
       },
@@ -6523,27 +6605,31 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "6.0.0",
         "vscode-languageserver-types": "3.16.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
+      "integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==",
+      "dev": true
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.16.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
     },
     "node_modules/vscode-nls": {
       "version": "5.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==",
+      "dev": true
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
@@ -6559,8 +6645,9 @@
     },
     "node_modules/vscode-uri": {
       "version": "3.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
+      "dev": true
     },
     "node_modules/vue": {
       "version": "3.2.31",
@@ -6645,17 +6732,19 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.0.0",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/zod": {
-      "version": "3.11.6",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.13.4.tgz",
+      "integrity": "sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6680,22 +6769,25 @@
       }
     },
     "@astrojs/compiler": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.11.4.tgz",
-      "integrity": "sha512-T598FTCgBFjjPLPClvn+lc2SFGAJkjaF+lbxvHNjzmUpOYdz7YyH1apd3XAZvDp5r5WBBhicB6693GhQRpf3oQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.12.0.tgz",
+      "integrity": "sha512-P1OibxzBRkWz18FL9IClI4WIOL6fFHqrmYq+/Ygw3ya0GHeDZ8pLFVpLXTPKMdHoys43dwffPA/6pWaFygBlEw==",
       "dev": true,
       "requires": {
-        "typescript": "^4.3.5"
+        "tsm": "^2.2.1",
+        "uvu": "^0.5.3"
       }
     },
     "@astrojs/language-server": {
-      "version": "0.8.6",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-0.8.10.tgz",
+      "integrity": "sha512-F3ceZrBKywnNkDq9mK/6RgRDAGUAv9Z45oljpBx9dlMQHnWOnPdJFWncw1jVItAT57SEflLJqTuFaDphKQAFtQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
         "source-map": "^0.7.3",
         "ts-morph": "^12.0.0",
-        "typescript": "^4.5.2",
+        "typescript": "^4.5.4",
         "vscode-css-languageservice": "^5.1.1",
         "vscode-emmet-helper": "2.1.2",
         "vscode-html-languageservice": "^3.0.3",
@@ -6792,8 +6884,10 @@
         "vue": "^3.2.30"
       }
     },
-    "@astropub/webapi": {
-      "version": "0.10.14",
+    "@astrojs/webapi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/webapi/-/webapi-0.11.0.tgz",
+      "integrity": "sha512-hzltX2kPjAX0zEKymU7ceDLCqkZN0ztgucqAzyvM62TJdznv/HRniJz850qKcqAcoTqDXBH5j/5FCO0GXSQLbw==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -7020,7 +7114,9 @@
       }
     },
     "@emmetio/abbreviation": {
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz",
+      "integrity": "sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==",
       "dev": true,
       "requires": {
         "@emmetio/scanner": "^1.0.0"
@@ -7028,6 +7124,8 @@
     },
     "@emmetio/css-abbreviation": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz",
+      "integrity": "sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==",
       "dev": true,
       "requires": {
         "@emmetio/scanner": "^1.0.0"
@@ -7035,6 +7133,8 @@
     },
     "@emmetio/scanner": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==",
       "dev": true
     },
     "@jridgewell/resolve-uri": {
@@ -7073,6 +7173,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
     },
     "@proload/core": {
       "version": "0.2.2",
@@ -7135,6 +7241,8 @@
     },
     "@ts-morph/common": {
       "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.7",
@@ -7145,6 +7253,8 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
       }
@@ -7156,39 +7266,6 @@
       "dev": true,
       "requires": {
         "@types/estree": "*"
-      }
-    },
-    "@types/babel__core": {
-      "version": "7.1.18",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "@types/babel__generator": {
-      "version": "7.6.4",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@types/babel__template": {
-      "version": "7.4.1",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@types/babel__traverse": {
-      "version": "7.14.2",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.3.0"
       }
     },
     "@types/debug": {
@@ -7307,12 +7384,6 @@
     },
     "@types/unist": {
       "version": "2.0.6"
-    },
-    "@types/yargs-parser": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.2.tgz",
-      "integrity": "sha512-sUWMriymrSqTvxCmCkf+7k392TNDcMJBHI1/rysWJxKnWAan/Zk4gZ/GEieSRo4EqIEPpbGU3Sd/0KTRoIA3pA==",
-      "dev": true
     },
     "@vitejs/plugin-vue": {
       "version": "2.2.2",
@@ -7466,6 +7537,8 @@
     },
     "ansi-regex": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true
     },
     "ansi-styles": {
@@ -7520,64 +7593,62 @@
       }
     },
     "astro": {
-      "version": "0.23.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.23.7.tgz",
-      "integrity": "sha512-2hoh9NDhDpy25AKsdD/KRNzl832F46/t2dvyaKo5LfnTvJEBV0agPTOC4K6wI3IDqDQBTiizHXwqgm3e/lX7rA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.24.0.tgz",
+      "integrity": "sha512-KN0EtbypW+OC2MQOEH2wBcNlX0Vuu/+DMLVCJsaH2RnvzONunuWxZdNxKCO8EM7fnx8TlH+vA9VaBXcdm5iWTA==",
       "dev": true,
       "requires": {
-        "@astrojs/compiler": "^0.11.4",
-        "@astrojs/language-server": "^0.8.6",
+        "@astrojs/compiler": "^0.12.0",
+        "@astrojs/language-server": "^0.8.10",
         "@astrojs/markdown-remark": "^0.6.4",
         "@astrojs/prism": "0.4.0",
         "@astrojs/renderer-preact": "^0.5.0",
         "@astrojs/renderer-react": "0.5.0",
         "@astrojs/renderer-svelte": "0.5.1",
         "@astrojs/renderer-vue": "0.4.0",
-        "@astropub/webapi": "^0.10.1",
-        "@babel/core": "^7.15.8",
-        "@babel/traverse": "^7.15.4",
+        "@astrojs/webapi": "^0.11.0",
+        "@babel/core": "^7.17.5",
+        "@babel/traverse": "^7.17.3",
         "@proload/core": "^0.2.2",
-        "@proload/plugin-tsm": "^0.1.0",
-        "@types/babel__core": "^7.1.15",
-        "@types/debug": "^4.1.7",
-        "@types/yargs-parser": "^20.2.1",
+        "@proload/plugin-tsm": "^0.1.1",
         "@web/parse5-utils": "^1.3.0",
-        "ci-info": "^3.2.0",
+        "ci-info": "^3.3.0",
         "common-ancestor-path": "^1.0.1",
+        "debug": "^4.3.3",
         "eol": "^0.9.1",
-        "es-module-lexer": "^0.9.3",
-        "esbuild": "0.13.7",
-        "estree-walker": "^3.0.0",
-        "fast-glob": "^3.2.7",
-        "fast-xml-parser": "^4.0.0-beta.3",
+        "es-module-lexer": "^0.10.0",
+        "esbuild": "0.14.25",
+        "estree-walker": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "fast-xml-parser": "^4.0.6",
         "html-entities": "^2.3.2",
-        "htmlparser2": "^7.1.2",
+        "htmlparser2": "^7.2.0",
         "kleur": "^4.1.4",
-        "magic-string": "^0.25.7",
-        "micromorph": "^0.1.1",
+        "magic-string": "^0.25.9",
+        "micromorph": "^0.1.2",
         "mime": "^3.0.0",
         "parse5": "^6.0.1",
         "path-to-regexp": "^6.2.0",
-        "postcss": "^8.3.8",
-        "prismjs": "^1.25.0",
-        "rehype-slug": "^5.0.0",
-        "resolve": "^1.20.0",
-        "rollup": "^2.64.0",
+        "postcss": "^8.4.8",
+        "prismjs": "^1.27.0",
+        "rehype-slug": "^5.0.1",
+        "resolve": "^1.22.0",
+        "rollup": "^2.70.0",
         "semver": "^7.3.5",
-        "send": "^0.17.1",
         "serialize-javascript": "^6.0.0",
-        "shiki": "^0.10.0",
+        "shiki": "^0.10.1",
         "shorthash": "^0.0.2",
+        "sirv": "^2.0.2",
         "slash": "^4.0.0",
         "sourcemap-codec": "^1.4.8",
         "srcset-parse": "^1.1.0",
-        "string-width": "^5.0.0",
+        "string-width": "^5.1.2",
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
         "vite": "^2.8.6",
-        "yargs-parser": "^21.0.0",
-        "zod": "^3.8.1"
+        "yargs-parser": "^21.0.1",
+        "zod": "^3.13.4"
       }
     },
     "autoprefixer": {
@@ -7746,6 +7817,8 @@
     },
     "code-block-writer": {
       "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
       "dev": true
     },
     "color-convert": {
@@ -7880,22 +7953,10 @@
         "meow": "^6.1.1"
       }
     },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
-    },
     "dequal": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
       "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "dev": true
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-indent": {
@@ -7968,33 +8029,27 @@
     },
     "eastasianwidth": {
       "version": "0.2.0",
-      "dev": true
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
     "electron-to-chromium": {
       "version": "1.4.46"
     },
     "emmet": {
-      "version": "2.3.5",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.3.6.tgz",
+      "integrity": "sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==",
       "dev": true,
       "requires": {
-        "@emmetio/abbreviation": "^2.2.2",
+        "@emmetio/abbreviation": "^2.2.3",
         "@emmetio/css-abbreviation": "^2.1.4"
       }
     },
     "emoji-regex": {
       "version": "9.2.2",
-      "dev": true
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
     "entities": {
@@ -8040,7 +8095,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.0.tgz",
+      "integrity": "sha512-0fHYovx7ETE13wPL8zG/V+ElEgSeSwsgRVOvNZ+g/Y/2YyJq75+IEY4ZBr59vUZ3Voci1jBIktwpj8oODaWa+g==",
       "dev": true
     },
     "es-to-primitive": {
@@ -8067,41 +8124,175 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.13.7",
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+      "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
       "dev": true,
       "requires": {
-        "esbuild-android-arm64": "0.13.7",
-        "esbuild-darwin-64": "0.13.7",
-        "esbuild-darwin-arm64": "0.13.7",
-        "esbuild-freebsd-64": "0.13.7",
-        "esbuild-freebsd-arm64": "0.13.7",
-        "esbuild-linux-32": "0.13.7",
-        "esbuild-linux-64": "0.13.7",
-        "esbuild-linux-arm": "0.13.7",
-        "esbuild-linux-arm64": "0.13.7",
-        "esbuild-linux-mips64le": "0.13.7",
-        "esbuild-linux-ppc64le": "0.13.7",
-        "esbuild-netbsd-64": "0.13.7",
-        "esbuild-openbsd-64": "0.13.7",
-        "esbuild-sunos-64": "0.13.7",
-        "esbuild-windows-32": "0.13.7",
-        "esbuild-windows-64": "0.13.7",
-        "esbuild-windows-arm64": "0.13.7"
+        "esbuild-android-64": "0.14.25",
+        "esbuild-android-arm64": "0.14.25",
+        "esbuild-darwin-64": "0.14.25",
+        "esbuild-darwin-arm64": "0.14.25",
+        "esbuild-freebsd-64": "0.14.25",
+        "esbuild-freebsd-arm64": "0.14.25",
+        "esbuild-linux-32": "0.14.25",
+        "esbuild-linux-64": "0.14.25",
+        "esbuild-linux-arm": "0.14.25",
+        "esbuild-linux-arm64": "0.14.25",
+        "esbuild-linux-mips64le": "0.14.25",
+        "esbuild-linux-ppc64le": "0.14.25",
+        "esbuild-linux-riscv64": "0.14.25",
+        "esbuild-linux-s390x": "0.14.25",
+        "esbuild-netbsd-64": "0.14.25",
+        "esbuild-openbsd-64": "0.14.25",
+        "esbuild-sunos-64": "0.14.25",
+        "esbuild-windows-32": "0.14.25",
+        "esbuild-windows-64": "0.14.25",
+        "esbuild-windows-arm64": "0.14.25"
       }
     },
+    "esbuild-android-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+      "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+      "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+      "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+      "dev": true,
+      "optional": true
+    },
     "esbuild-darwin-arm64": {
-      "version": "0.13.7",
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+      "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+      "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+      "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+      "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+      "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+      "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+      "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+      "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+      "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+      "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+      "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+      "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+      "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+      "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+      "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+      "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+      "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
       "dev": true,
       "optional": true
     },
     "escalade": {
       "version": "3.1.1"
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5"
@@ -8132,12 +8323,6 @@
       "version": "3.0.1",
       "dev": true
     },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
-    },
     "extend": {
       "version": "3.0.2"
     },
@@ -8161,7 +8346,9 @@
       }
     },
     "fast-xml-parser": {
-      "version": "4.0.1",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.6.tgz",
+      "integrity": "sha512-RHz47iX/DKT6BQwYQUmKG/1fuC5g2s/TibpxNvE+0ysnpSJxePFzsJvRDtfGhLRg3zdKMzO6EJn8n7+AJ6pSHg==",
       "dev": true,
       "requires": {
         "strnum": "^1.0.5"
@@ -8195,12 +8382,6 @@
     },
     "fraction.js": {
       "version": "4.1.2"
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8494,19 +8675,6 @@
         "domhandler": "^4.2.2",
         "domutils": "^2.8.0",
         "entities": "^3.0.1"
-      }
-    },
-    "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
       }
     },
     "ieee754": {
@@ -8827,6 +8995,8 @@
     },
     "lodash": {
       "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.castarray": {
@@ -8862,10 +9032,12 @@
       }
     },
     "magic-string": {
-      "version": "0.25.7",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "map-obj": {
@@ -9571,6 +9743,12 @@
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true
     },
+    "mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "dev": true
@@ -9659,15 +9837,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "dev": true,
@@ -9748,6 +9917,8 @@
     },
     "path-browserify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
     },
     "path-exists": {
@@ -9775,9 +9946,11 @@
       "version": "2.3.1"
     },
     "postcss": {
-      "version": "8.4.6",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "requires": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -9863,12 +10036,6 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true
     },
     "react": {
       "version": "17.0.2",
@@ -10117,7 +10284,9 @@
       }
     },
     "rollup": {
-      "version": "2.68.0",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -10191,70 +10360,12 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.8.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
-      }
-    },
     "serialize-javascript": {
       "version": "6.0.0",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
       }
-    },
-    "setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
     },
     "shiki": {
       "version": "0.10.1",
@@ -10282,6 +10393,17 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sirv": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
+      "integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      }
+    },
     "slash": {
       "version": "4.0.0",
       "dev": true
@@ -10300,6 +10422,8 @@
     },
     "source-map": {
       "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "dev": true
     },
     "source-map-js": {
@@ -10349,14 +10473,10 @@
       "version": "1.1.0",
       "dev": true
     },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
-    },
     "string-width": {
-      "version": "5.1.0",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "requires": {
         "eastasianwidth": "^0.2.0",
@@ -10396,6 +10516,8 @@
     },
     "strip-ansi": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "dev": true,
       "requires": {
         "ansi-regex": "^6.0.1"
@@ -10420,6 +10542,8 @@
     },
     "strnum": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "style-to-object": {
@@ -10562,10 +10686,10 @@
         "is-number": "^7.0.0"
       }
     },
-    "toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+    "totalist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.0.tgz",
+      "integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
       "dev": true
     },
     "trim-newlines": {
@@ -10577,6 +10701,8 @@
     },
     "ts-morph": {
       "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.2.0.tgz",
+      "integrity": "sha512-WHXLtFDcIRwoqaiu0elAoZ/AmI+SwwDafnPKjgJmdwJ2gRVO0jMKBt88rV2liT/c6MTsXyuWbGFiHe9MRddWJw==",
       "dev": true,
       "requires": {
         "@ts-morph/common": "~0.11.1",
@@ -10600,37 +10726,6 @@
       "dev": true,
       "requires": {
         "esbuild": "^0.14.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.14.11",
-          "dev": true,
-          "requires": {
-            "esbuild-android-arm64": "0.14.11",
-            "esbuild-darwin-64": "0.14.11",
-            "esbuild-darwin-arm64": "0.14.11",
-            "esbuild-freebsd-64": "0.14.11",
-            "esbuild-freebsd-arm64": "0.14.11",
-            "esbuild-linux-32": "0.14.11",
-            "esbuild-linux-64": "0.14.11",
-            "esbuild-linux-arm": "0.14.11",
-            "esbuild-linux-arm64": "0.14.11",
-            "esbuild-linux-mips64le": "0.14.11",
-            "esbuild-linux-ppc64le": "0.14.11",
-            "esbuild-linux-s390x": "0.14.11",
-            "esbuild-netbsd-64": "0.14.11",
-            "esbuild-openbsd-64": "0.14.11",
-            "esbuild-sunos-64": "0.14.11",
-            "esbuild-windows-32": "0.14.11",
-            "esbuild-windows-64": "0.14.11",
-            "esbuild-windows-arm64": "0.14.11"
-          }
-        },
-        "esbuild-darwin-arm64": {
-          "version": "0.14.11",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "twitter-api-client": {
@@ -10852,42 +10947,12 @@
         "postcss": "^8.4.6",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.14.23",
-          "dev": true,
-          "requires": {
-            "esbuild-android-arm64": "0.14.23",
-            "esbuild-darwin-64": "0.14.23",
-            "esbuild-darwin-arm64": "0.14.23",
-            "esbuild-freebsd-64": "0.14.23",
-            "esbuild-freebsd-arm64": "0.14.23",
-            "esbuild-linux-32": "0.14.23",
-            "esbuild-linux-64": "0.14.23",
-            "esbuild-linux-arm": "0.14.23",
-            "esbuild-linux-arm64": "0.14.23",
-            "esbuild-linux-mips64le": "0.14.23",
-            "esbuild-linux-ppc64le": "0.14.23",
-            "esbuild-linux-riscv64": "0.14.23",
-            "esbuild-linux-s390x": "0.14.23",
-            "esbuild-netbsd-64": "0.14.23",
-            "esbuild-openbsd-64": "0.14.23",
-            "esbuild-sunos-64": "0.14.23",
-            "esbuild-windows-32": "0.14.23",
-            "esbuild-windows-64": "0.14.23",
-            "esbuild-windows-arm64": "0.14.23"
-          }
-        },
-        "esbuild-darwin-arm64": {
-          "version": "0.14.23",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "vscode-css-languageservice": {
-      "version": "5.1.9",
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.13.tgz",
+      "integrity": "sha512-FA0foqMzMmEoO0WJP+MjoD4dRERhKS+Ag+yBrtmWQDmw2OuZ1R/5FkvI/XdTkCpHmTD9VMczugpHRejQyTXCNQ==",
       "dev": true,
       "requires": {
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -10898,6 +10963,8 @@
     },
     "vscode-emmet-helper": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.1.2.tgz",
+      "integrity": "sha512-Fy6UNawSgxE3Kuqi54vSXohf03iOIrp1A74ReAgzvGP9Yt7fUAvkqF6No2WAc34/w0oWAHAeqoBNqmKKWh6U5w==",
       "dev": true,
       "requires": {
         "emmet": "^2.1.5",
@@ -10910,16 +10977,22 @@
       "dependencies": {
         "jsonc-parser": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+          "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
           "dev": true
         },
         "vscode-uri": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+          "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
           "dev": true
         }
       }
     },
     "vscode-html-languageservice": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.2.0.tgz",
+      "integrity": "sha512-aLWIoWkvb5HYTVE0kI9/u3P0ZAJGrYOSAAE6L0wqB9radKRtbJNrF9+BjSUFyCgBdNBE/GFExo35LoknQDJrfw==",
       "dev": true,
       "requires": {
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -10930,20 +11003,28 @@
       "dependencies": {
         "vscode-languageserver-types": {
           "version": "3.16.0-next.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+          "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
           "dev": true
         },
         "vscode-uri": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+          "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
           "dev": true
         }
       }
     },
     "vscode-jsonrpc": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "dev": true
     },
     "vscode-languageserver": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
       "dev": true,
       "requires": {
         "vscode-languageserver-protocol": "^3.15.3"
@@ -10951,6 +11032,8 @@
     },
     "vscode-languageserver-protocol": {
       "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dev": true,
       "requires": {
         "vscode-jsonrpc": "6.0.0",
@@ -10958,15 +11041,21 @@
       }
     },
     "vscode-languageserver-textdocument": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
+      "integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==",
       "dev": true
     },
     "vscode-languageserver-types": {
       "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
       "dev": true
     },
     "vscode-nls": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==",
       "dev": true
     },
     "vscode-oniguruma": {
@@ -10983,6 +11072,8 @@
     },
     "vscode-uri": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
       "dev": true
     },
     "vue": {
@@ -11044,11 +11135,15 @@
       "version": "1.10.2"
     },
     "yargs-parser": {
-      "version": "21.0.0",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true
     },
     "zod": {
-      "version": "3.11.6",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.13.4.tgz",
+      "integrity": "sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg==",
       "dev": true
     },
     "zwitch": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "yarn prettier -w ."
   },
   "devDependencies": {
-    "astro": "^0.23.7",
+    "astro": "^0.24.0",
     "autoprefixer": "^10.3.7",
     "prettier-plugin-astro": "^0.0.12",
     "tailwindcss": "^3.0.15"

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1,3 +1,5 @@
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono);
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -58,7 +60,6 @@
     border-top-left-radius: 3px;
 }
 
-@import url(https://fonts.googleapis.com/css?family=Fira+Mono);
 /*
  * Hopscotch
  * by Jan T. Sott

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -1,14 +1,10 @@
 async function load() {
-  const fetchedPosts = await import.meta.glob("../pages/posts/*.md");
-  const mappedPosts = await Promise.all(
-    Object.keys(fetchedPosts).map((key) => {
+  const fetchedPosts = import.meta.globEager("../pages/posts/*.md");
+  const mappedPosts =  Object.keys(fetchedPosts).map((key) => {
       const post = fetchedPosts[key];
       const url = key.replace("../pages/", "/").replace(".md", "/");
-      return post().then((p) => {
-        return { ...p.frontmatter, url };
-      });
-    })
-  );
+      return { ...post.frontmatter, url };
+    });
 
   return mappedPosts;
 }


### PR DESCRIPTION
- Upgrade Astro to v0.24.0 (not required, just useful for my testing. You should probably test this locally in dev before merging)
- Convert `import.meta.glob` to `import.meta.globEager`. This should be more performant since it uses static ESM imports instead of dynamic ones.

Most of the perf wins are in a separate Astro PR (still TODO) but this should still have a noticeable impact.